### PR TITLE
Feat: 127 enable filtering by accounts

### DIFF
--- a/frontend/src/pages/transactions/TransactionsView.vue
+++ b/frontend/src/pages/transactions/TransactionsView.vue
@@ -278,7 +278,6 @@ function onMove(evt) {
 }
 
 function formatAccounts(accountID) {
-  console.log('formatAccounts called with:', accountID);
   const result = accountsStore.getAccountById(accountID);
   return result.name || '-';
 }

--- a/frontend/src/pages/transactions/TransactionsView.vue
+++ b/frontend/src/pages/transactions/TransactionsView.vue
@@ -30,10 +30,19 @@
           </div>
           <div class="col-8 col-md-4 m-0">
             <div class="form-floating">
-              <select class="form-select bg-body-tertiary text-light-emphasis" id="account">
-                <option selected>All Accounts</option>
-                <option>Debit Card</option>
-                <option>Mexico Account</option>
+              <select
+                class="form-select bg-body-tertiary text-light-emphasis"
+                id="account"
+                v-model="selectedAccountId"
+              >
+                <option :value="null">All Accounts</option>
+                <option
+                  v-for="account in accountsStore.accounts"
+                  :key="account.id"
+                  :value="account.id"
+                >
+                  {{ account.name }}
+                </option>
               </select>
               <label for="account" class="text-light-emphasis">Account</label>
             </div>
@@ -181,6 +190,7 @@ const sortDirection = ref('asc'); // 'asc' or 'desc'
 const workspaceCurrencySymbol = workspacesStore?.currentWorkspace?.currency_symbol;
 
 const searchQuery = ref('');
+const selectedAccountId = ref(null);
 
 const defaultColumns = [
   { key: 'select', label: '', thClass: '', tdClass: '' },
@@ -203,40 +213,47 @@ const columnsnames = columns.value.map(col => ({
 const headers = ref([...columnsnames]);
 
 const filteredTransactions = computed(() => {
-  if (!searchQuery.value.trim()) return transactions.value;
-  const query = searchQuery.value.trim().toLowerCase();
-  return transactions.value.filter(tx => {
-    // Check all columns for a match
-    return columns.value.some(col => {
-      let value = '';
-      switch (col.key) {
-        case 'description':
-          value = tx.description;
-          break;
-        case 'amount':
-          value = String(tx.amount);
-          break;
-        case 'account':
-          value = formatAccounts(tx.account_id);
-          break;
-        case 'category':
-          value = tx.category_name;
-          break;
-        case 'type':
-          value = formatTransactionType(tx);
-          break;
-        case 'date':
-          value = tx.date;
-          break;
-        case 'note':
-          value = tx.note;
-          break;
-        default:
-          value = '';
-      }
-      return (value || '').toLowerCase().includes(query);
+  let txs = transactions.value;
+  // Filter by search query
+  let query = searchQuery.value !== '' ? searchQuery.value.trim().toLowerCase() : '';
+  // Filter by account if selected
+  if (selectedAccountId.value) {
+    txs = txs.filter(tx => tx.account_id === selectedAccountId.value);
+  }
+  
+    txs = txs.filter(tx => {
+      return columns.value.some(col => {
+        let value = '';
+        switch (col.key) {
+          case 'description':
+            value = tx.description;
+            break;
+          case 'amount':
+            value = String(tx.amount);
+            break;
+          case 'account':
+            value = formatAccounts(tx.account_id);
+            break;
+          case 'category':
+            value = tx.category_name;
+            break;
+          case 'type':
+            value = formatTransactionType(tx);
+            break;
+          case 'date':
+            value = tx.date;
+            break;
+          case 'note':
+            value = tx.note;
+            break;
+          default:
+            value = '';
+        }
+        return (value || '').toLowerCase().includes(query);
+      });
     });
-  });
+  // If no search query or category selected, return all transactions
+  return txs;
 });
 
 // ----------------- Synchronous Functions -----------------


### PR DESCRIPTION
## Pull Request: Add Account Filter to Transactions View

### Summary

This PR implements account-based filtering for the Transactions page. Users can now filter the displayed transactions by selecting a specific account from a dropdown menu. The dropdown is dynamically populated from the accounts store, ensuring it always reflects the current set of accounts in the workspace.

### Details

- The account filter `<select>` is now bound to a `selectedAccountId` ref.
- The dropdown options are generated from `accountsStore.accounts`, with an "All Accounts" option to show all transactions.
- The `filteredTransactions` computed property was updated to filter transactions by the selected account, in addition to any search query.
- The filter works seamlessly with existing search and sorting functionalities.
- No changes were made to the reset filters button or logic, as that will be handled separately.

### User Experience

- Users can quickly narrow down transactions to a specific account or view all accounts.
- All other features (search, sorting, column reordering) remain fully functional and compatible.

### Browser Testing

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/b16cb84a-6ff5-4734-ae4e-a346e17cd1a6" />
<img width="1116" alt="Screenshot 2025-07-03 at 11 35 29 p m" src="https://github.com/user-attachments/assets/d94cd208-d872-4fe4-945e-ce17b4cd9701" />



---

Closes #127