### PR TITLE
feat: 136 reset filters button functionality

### DIFF
--- a/frontend/src/pages/transactions/TransactionsView.vue
+++ b/frontend/src/pages/transactions/TransactionsView.vue
@@ -48,7 +48,7 @@
             </div>
           </div>
           <div class="col-4 col-md-2 m-0">
-            <button class="btn btn-info w-100" type="button">Reset Filters</button>
+            <button class="btn btn-info w-100" type="button" @click="resetFilters">Reset Filters</button>
           </div>
         </form>
         <!-- Sortable Table -->
@@ -220,41 +220,46 @@ const filteredTransactions = computed(() => {
   if (selectedAccountId.value) {
     txs = txs.filter(tx => tx.account_id === selectedAccountId.value);
   }
-  
-    txs = txs.filter(tx => {
-      return columns.value.some(col => {
-        let value = '';
-        switch (col.key) {
-          case 'description':
-            value = tx.description;
-            break;
-          case 'amount':
-            value = String(tx.amount);
-            break;
-          case 'account':
-            value = formatAccounts(tx.account_id);
-            break;
-          case 'category':
-            value = tx.category_name;
-            break;
-          case 'type':
-            value = formatTransactionType(tx);
-            break;
-          case 'date':
-            value = tx.date;
-            break;
-          case 'note':
-            value = tx.note;
-            break;
-          default:
-            value = '';
-        }
-        return (value || '').toLowerCase().includes(query);
-      });
+  txs = txs.filter(tx => {
+    return columns.value.some(col => {
+      let value = '';
+      switch (col.key) {
+        case 'description':
+          value = tx.description;
+          break;
+        case 'amount':
+          value = String(tx.amount);
+          break;
+        case 'account':
+          value = formatAccounts(tx.account_id);
+          break;
+        case 'category':
+          value = tx.category_name;
+          break;
+        case 'type':
+          value = formatTransactionType(tx);
+          break;
+        case 'date':
+          value = tx.date;
+          break;
+        case 'note':
+          value = tx.note;
+          break;
+        default:
+          value = '';
+      }
+      return (value || '').toLowerCase().includes(query);
     });
+  });
   // If no search query or category selected, return all transactions
   return txs;
 });
+
+// Reset Filters functionality
+function resetFilters() {
+  searchQuery.value = '';
+  selectedAccountId.value = null;
+}
 
 // ----------------- Synchronous Functions -----------------
 function getColumnsStorageKey() {


### PR DESCRIPTION
## Pull Request: Add Reset Filters Functionality to Transactions View

### Summary

This PR implements the "Reset Filters" feature for the Transactions page. Users can now quickly clear all applied filters (search and account selection) with a single click, restoring the full list of transactions.

### Details

- A `resetFilters` method was added to the TransactionsView component.
- The "Reset Filters" button now calls `resetFilters`, which:
  - Clears the search query.
  - Resets the selected account to "All Accounts".
- The filter state is immediately reflected in the transaction list, ensuring a smooth user experience.
- The implementation follows the existing Vue 3 Composition API and Bootstrap 5.3 styling conventions.

### User Experience

- Users can easily return to the unfiltered transaction list with one click.
- The feature works seamlessly with all other filters and sorting options.
- UI remains consistent with the rest of the application.

---

Closes #136 